### PR TITLE
fix canary ws connection ig

### DIFF
--- a/src/transports/websocket.js
+++ b/src/transports/websocket.js
@@ -63,7 +63,7 @@ export default class WSServer {
 
     if (process.env.ARRPC_DEBUG) log(`new connection! origin:`, origin, JSON.parse(JSON.stringify(params)));
 
-    if (origin !== '' && ![ 'https://discord.com', 'https://ptb.discord.com', 'https://canary.discord.com/' ].includes(origin)) {
+    if (origin !== '' && ![ 'https://discord.com', 'https://ptb.discord.com', 'https://canary.discord.com' ].includes(origin)) {
       log('disallowed origin', origin);
 
       socket.close();


### PR DESCRIPTION
why ¿
![cmd_Lu73nXWaFu](https://github.com/OpenAsar/arrpc/assets/54238880/7b2960aa-28a9-4190-ae9a-930f38ec59bf)

(not sure which application use it but why only canary have '/' at the end)
