### PR TITLE
Fix pypresence compatibility

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -74,11 +74,21 @@ export default class RPCServer extends EventEmitter {
       case 'SET_ACTIVITY':
         const { activity, pid } = args; // translate given parameters into what discord dispatch expects
 
-        if (!activity) return this.emit('activity', {
-          activity: null,
-          pid,
-          socketId: socket.socketId.toString()
-        });
+        if (!activity) {
+          // Activity clear
+          socket.send?.({
+            cmd,
+            data: null,
+            evt: null,
+            nonce
+          });
+          
+          return this.emit('activity', {
+            activity: null,
+            pid,
+            socketId: socket.socketId.toString()
+          });
+        }
 
         const { buttons, timestamps, instance } = activity;
 


### PR DESCRIPTION
Pypresence (and possibly other clients as well) expects an acknowledgement when clearing the rich presence, which previously wasn't sent if there was no activity data. This PR fixes that.

Resolves #38