### PR TITLE
Fix detection of most games running as admin

### DIFF
--- a/src/process/native/win32.js
+++ b/src/process/native/win32.js
@@ -1,9 +1,10 @@
 import { exec } from 'child_process';
 
-export const getProcesses = () => new Promise(res => exec(`wmic process get ProcessID,ExecutablePath /format:csv`, (e, out) => {
+export const getProcesses = () => new Promise(res => exec(`wmic process get ProcessID,ExecutablePath,Name /format:csv`, (e, out) => {
   res(out.toString().split('\r\n').slice(2).map(x => {
     const parsed = x.trim().split(',').slice(1).reverse();
     parsed[0] = parseInt(parsed[0]) || parsed[0]; // pid to int
-    return parsed;
+    parsed[1] = parsed[2] || parsed[1]
+    return parsed.slice(0, 2);
   }).filter(x => x[1]));
 }));

--- a/src/process/native/win32.js
+++ b/src/process/native/win32.js
@@ -2,9 +2,8 @@ import { exec } from 'child_process';
 
 export const getProcesses = () => new Promise(res => exec(`wmic process get ProcessID,ExecutablePath,Name /format:csv`, (e, out) => {
   res(out.toString().split('\r\n').slice(2).map(x => {
+    // [ProcessId, Name, ExecutablePath]
     const parsed = x.trim().split(',').slice(1).reverse();
-    parsed[0] = parseInt(parsed[0]) || parsed[0]; // pid to int
-    parsed[1] = parsed[2] || parsed[1]
-    return parsed.slice(0, 2);
+    return [ parseInt(parsed[0]) || parsed[0], parsed[2] || parsed[1] ];
   }).filter(x => x[1]));
 }));


### PR DESCRIPTION
Games running as admin seem to not share their path with user-level wmic calls. However they do share their process name, which worked for me with Cuphead. I assume most games' process name will work too.

![cuphead pid in task manager](https://github.com/OpenAsar/arrpc/assets/20448879/ca04f08a-a472-4ebd-a15c-4b3cc5c54439)
`wmic process get ProcessID,ExecutablePath /format:csv`
![wmic output for pid with missing path](https://github.com/OpenAsar/arrpc/assets/20448879/648b5e79-44f1-43b5-a7b6-0b7c88e9ce98)

`wmic process get ProcessID,ExecutablePath,Name /format:csv`
![wmic output for pid with proces name](https://github.com/OpenAsar/arrpc/assets/20448879/78b1d1d9-b625-4be0-8286-f516473581e0)
