### PR TITLE
fix(linux): make process detection work regardless of `ps` impl

### DIFF
--- a/src/process/native/linux.js
+++ b/src/process/native/linux.js
@@ -1,17 +1,8 @@
-import { exec } from 'child_process';
-import { readlink } from 'fs/promises';
+import { readdir, readlink } from 'fs/promises';
 
-export const getProcesses = () => new Promise(res => exec(`ps a -o "%p;%c;%a"`, async (e, out) => {
-  res((await Promise.all(out.toString().split('\n').slice(1, -1).map(async x => {
-    const split = x.trim().split(';');
-    // if (split.length === 1) return;
-
-    const pid = parseInt(split[0].trim());
-    const cmd = split[1].trim();
-    const argv = split.slice(2).join(';').trim();
-
-    const path = await readlink(`/proc/${pid}/exe`).catch(e => {}); // read path from /proc/{pid}/exe symlink
-
-    return [ pid, path ];
-  }))).filter(x => x && x[1]));
-}));
+export const getProcesses = async () => {
+  const pids = (await readdir("/proc")).filter((f) => !isNaN(+f));
+  return (await Promise.all(pids.map((pid) =>
+    readlink(`/proc/${pid}/exe`).then((path) => [+pid, path], () => {})
+  ))).filter(x => x);
+}


### PR DESCRIPTION
Basically the title. Tested on Arch, but should work on most distros

Needed because currently this happens:

![image](https://github.com/OpenAsar/arrpc/assets/142252300/a0b17cd9-a88f-4ced-8a2e-1e3e6c76ac5f)
