### PR TITLE
Add "bin" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   "dependencies": {
     "ws": "^8.11.0"
   },
-  "type": "module"
+  "type": "module",
+  "bin": {
+    "arrpc": "src/index.js"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const rgb = (r, g, b, msg) => `\x1b[38;2;${r};${g};${b}m${msg}\x1b[0m`;
 const log = (...args) => console.log(`[${rgb(88, 101, 242, 'arRPC')}]`, ...args);
 


### PR DESCRIPTION
Resolves #49.

Just to be clear, this does not build a binary. It just creates a symlink to `index.js` named `arrpc` that can be used as a standalone executable when `arrpc` is installed.