### PR TITLE
Proper Linux Game Detection

### DIFF
--- a/src/process/native/linux.js
+++ b/src/process/native/linux.js
@@ -1,8 +1,15 @@
-import { readdir, readlink } from 'fs/promises';
+import { readdir, readFile } from "fs/promises";
 
 export const getProcesses = async () => {
-  const pids = (await readdir("/proc")).filter((f) => !isNaN(+f));
-  return (await Promise.all(pids.map((pid) =>
-    readlink(`/proc/${pid}/exe`).then((path) => [+pid, path], () => {})
-  ))).filter(x => x);
-}
+  let pids = (await readdir("/proc")).filter((f) => !isNaN(+f));
+  return (
+    await Promise.all(
+      pids.map((pid) =>
+        readFile(`/proc/${pid}/cmdline`, "utf8").then(
+          (path) => [+pid, path.replace(/\0/g, "")],
+          () => {}
+        )
+      )
+    )
+  ).filter((x) => x);
+};


### PR DESCRIPTION
## What does this PR fix/add

Currently, the Linux implementation of process scanning simply reads the `/proc/<pid>/exe` symlink of each numbered entry in `/proc`. In most (or all) cases this does not work, because `.exe` files are run with `wine` under Linux. The result being that `/proc/<pid>/exe` simply points to the `wine` binary that was used to run a game and not the actual game executable.

My implementation differs in that it uses the output of `/proc/<pid>/cmdline`, which contains the full command used to start a game (and therefore also contains the actual `.exe` name). Since this file is null-terminated, `replace()` is used to remove the null terminators from the parsed string.

## Is this PR ready to merge

The only consideration is that this is a bit more costly in terms of processing needed than just reading symlinks, with the tradeoff being that it now actually works correctly. It might be worth to consider trying a version that simply calls `/bin/ps` for a list of the current processes, but I don't know if the difference in performance would be better or worse.