### PR TITLE
More efficient Process Scanning

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -16,6 +16,8 @@ export default class ProcessServer {
 
     this.scan = this.scan.bind(this);
 
+    this.processes = [];
+
     this.scan();
     setInterval(this.scan, 5000);
 
@@ -24,12 +26,17 @@ export default class ProcessServer {
 
   async scan() {
     const startTime = performance.now();
-    const processes = await Native.getProcesses();
     const ids = [];
+
+    if (process.platform == 'linux') {
+      this.processes = await Native.getProcesses(this.processes);
+    } else {
+      this.processes = await Native.getProcesses();
+    }
 
     // log(`got processed in ${(performance.now() - startTime).toFixed(2)}ms`);
 
-    for (const [ pid, _path ] of processes) {
+    for (const [ pid, _path ] of this.processes) {
       const path = _path.toLowerCase().replaceAll('\\', '/');
       const toCompare = [ path.split('/').pop(), path.split('/').slice(-2).join('/') ];
 

--- a/src/process/native/linux.js
+++ b/src/process/native/linux.js
@@ -1,15 +1,21 @@
 import { readdir, readFile } from "fs/promises";
 
-export const getProcesses = async () => {
+export const getProcesses = async (currentProcs) => {
   let pids = (await readdir("/proc")).filter((f) => !isNaN(+f));
-  return (
+  let updatedProcs = currentProcs.filter((item) => pids.includes(item[0]));
+  let updatedPids = pids.filter(
+    (item) => !updatedProcs.map((item) => item[0]).includes(item)
+  );
+  let processes = (
     await Promise.all(
-      pids.map((pid) =>
+      updatedPids.map((pid) =>
         readFile(`/proc/${pid}/cmdline`, "utf8").then(
-          (path) => [+pid, path.replace(/\0/g, "")],
+          (path) => [pid, path.replace(/\0/g, "")],
           () => {}
         )
       )
     )
   ).filter((x) => x);
+  let adjustedList = [...processes, ...updatedProcs];
+  return adjustedList;
 };


### PR DESCRIPTION
## What does this PR fix/add

I made a PR that added proper process scanning for Linux that got merged recently, see #57. What I noticed, though, was that the amount of reads that are performed is exceptionally high, since we iterate over all `cmdline` entries in `/proc` all the time.
This PR aims to reduce the amount of times `arrpc` has to read these files by first checking what processes have changed in comparison to the previous scan iteration and only reading `cmdline` of newly added processes. This reduces the little "CPU spikes" that `arrpc` produces when performing a scan.

## Things to consider

I don't know if it would make sense to implement this for the Windows side of things, since I don't own a suitable machine to test. That's why there is an extra conditional check in `src/process/index.js` that checks for the correct platform because the Linux specific function takes an extra parameter now.