### PR TITLE
changed index path segments are enumerated from from 1 to 0

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -38,7 +38,7 @@ export default class ProcessServer {
       const path = _path.toLowerCase().replaceAll('\\', '/');
       const toCompare = [];
       const splitPath = path.split('/');
-      for (let i = 1; i < splitPath.length; i++) {
+      for (let i = 1; i <= splitPath.length; i++) {
         toCompare.push(splitPath.slice(-i).join('/'));
       }
 


### PR DESCRIPTION
I'm unsure whether this is on purpose but I thought I'd leave this here.

This fixes a game not being detected on my machine for which the path was just "bf4.exe" which was skipped by using index 1.