### PR TITLE
Improve linux game detection

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -34,11 +34,12 @@ export default class ProcessServer {
 
     // log(`got processed in ${(performance.now() - startTime).toFixed(2)}ms`);
 
-    for (const [ pid, _path, args ] of processes) {
+    for (const [ pid, _path, args, _cwdPath = '' ] of processes) {
       const path = _path.toLowerCase().replaceAll('\\', '/');
+      const cwdPath = _cwdPath.toLowerCase().replaceAll('\\', '/');
       const toCompare = [];
       const splitPath = path.split('/');
-      for (let i = 1; i < splitPath.length; i++) {
+      for (let i = 1; i < splitPath.length || i == 1; i++) {
         toCompare.push(splitPath.slice(-i).join('/'));
       }
 
@@ -51,7 +52,7 @@ export default class ProcessServer {
       for (const { executables, id, name } of DetectableDB) {
         if (executables?.some(x => {
           if (x.is_launcher) return false;
-          if (x.name[0] === '>' ? x.name.substring(1) !== toCompare[0] : !toCompare.some(y => x.name === y)) return false;
+          if (x.name[0] === '>' ? x.name.substring(1) !== toCompare[0] : !toCompare.some(y => x.name === y || `${cwdPath}/${y}`.includes(x.name))) return false;
           if (args && x.arguments) return args.join(" ").indexOf(x.arguments) > -1;
           return true;
         })) {

--- a/src/process/native/linux.js
+++ b/src/process/native/linux.js
@@ -1,8 +1,14 @@
-import { readdir, readFile } from "fs/promises";
+import { readdir, readFile, readlink } from "fs/promises";
 
 export const getProcesses = async () => (await Promise.all(
   (await readdir("/proc")).map(pid =>
     (+pid > 0) && readFile(`/proc/${pid}/cmdline`, 'utf8')
-      .then(path => [+pid, path.split("\0")[0], path.split("\0").slice(1)], () => 0)
+      .then(async path => {
+        let cwdPath;
+        try {
+          cwdPath = await readlink(`/proc/${pid}/cwd`);
+        } catch (err) {};
+        return [+pid, path.split("\0")[0], path.split("\0").slice(1), cwdPath]
+      }, () => 0)
   )
 )).filter(x => x);


### PR DESCRIPTION
Some games are listed in the discord game database with their parent directories but their launched processes on linux don't always have this included in their cmdline. This fixes that by checking processes with their working directories as well.

For example, this will now detect DOOM Eternal running through proton.