### PR TITLE
bridge: actually configurable port via $ARRPC_BRIDGE_PORT

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -10,7 +10,13 @@ export const send = msg => {
   wss.clients.forEach(x => x.send(JSON.stringify(msg)));
 };
 
-const port = 1337;
+let port = 1337;
+if (process.env.ARRPC_BRIDGE_PORT) {
+  port = parseInt(process.env.ARRPC_BRIDGE_PORT);
+  if (isNaN(port)) {
+    throw new Error('invalid port');
+  }
+}
 const wss = new WebSocketServer({ port });
 
 wss.on('connection', socket => {


### PR DESCRIPTION
This commit adds the $ARRPC_BRIDGE_PORT environment variable to allow
the parent process to configure the port the bridge listens on and avoid
using an existing port.

Fixes #84.
