### PR TITLE
CONNECTIONS_CALLBACK support - workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ Then just use apps with Discord RPC like normal and they *should* work!
 - [X] INVITE_BROWSER
 - [X] GUILD_TEMPLATE_BROWSER
 - [X] DEEP_LINK
+- [X] CONNECTIONS_CALLBACK 

--- a/src/server.js
+++ b/src/server.js
@@ -77,10 +77,12 @@ export default class RPCServer extends EventEmitter {
         // If it works - it works
         socket.send?.({
           cmd,
-          data: {code: 1000},
-          evt: "ERROR",
+          data: {
+            code: 1000
+          },
+          evt: 'ERROR',
           nonce
-        })
+        });
         break;
 
       case 'SET_ACTIVITY':

--- a/src/server.js
+++ b/src/server.js
@@ -73,6 +73,16 @@ export default class RPCServer extends EventEmitter {
     this.emit('message', { socket, cmd, args, nonce });
 
     switch (cmd) {
+      case "CONNECTIONS_CALLBACK":
+        // If it works - it works
+        socket.send?.({
+          cmd,
+          data: {code: 1000},
+          evt: "ERROR",
+          nonce
+        })
+        break;
+
       case 'SET_ACTIVITY':
         const { activity, pid } = args; // translate given parameters into what discord dispatch expects
 


### PR DESCRIPTION
When I was experimenting with Discord's RPC I accidentally found out that if you force error with code `1000` on `CONNECTIONS_CALLBACK` command (which is used for connecting accounts to profile) you can make the site connect your account through HTTP request instead while omiting the need of doing any request on server side.

This pull request adds my workaround for CONNECTIONS_CALLBACK which fixes account connecting on Discord. (and possibly adds support for it as I didn't notice this command being used for anything else.)

![Preview](https://github.com/user-attachments/assets/855288c9-cd18-4e27-a6f8-0e4dd58e6fa6)
