### PR TITLE
Cache the DetectableDB scan results

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -12,7 +12,7 @@ import * as Natives from './native/index.js';
 const Native = Natives[process.platform];
 
 
-const timestamps = {}, names = {}, pids = {};
+const timestamps = {}, names = {}, pids = {}, cache = {};
 export default class ProcessServer {
   constructor(handlers) {
     if (!Native) return; // log('unsupported platform:', process.platform);
@@ -36,52 +36,68 @@ export default class ProcessServer {
 
     for (const [ pid, _path, args ] of processes) {
       const path = _path.toLowerCase().replaceAll('\\', '/');
-      const toCompare = [];
-      const splitPath = path.split('/');
-      for (let i = 1; i < splitPath.length; i++) {
-        toCompare.push(splitPath.slice(-i).join('/'));
+      
+      // the cache key includes every dependency of the DetectableDB scan
+      const cacheKey = `${path}\0${args}`;
+      
+      var detected = [];
+      if (cache[cacheKey] !== undefined) {
+        detected = cache[cacheKey].detected;
       }
-
-      for (const p of toCompare.slice()) { // add more possible tweaked paths for less false negatives
-        toCompare.push(p.replace('64', '')); // remove 64bit identifiers-ish
-        toCompare.push(p.replace('.x64', ''));
-        toCompare.push(p.replace('x64', ''));
-        toCompare.push(p.replace('_64', ''));
-      }
-
-      for (const { executables, id, name } of DetectableDB) {
-        if (executables?.some(x => {
-          if (x.is_launcher) return false;
-          if (x.name[0] === '>' ? x.name.substring(1) !== toCompare[0] : !toCompare.some(y => x.name === y)) return false;
-          if (args && x.arguments) return args.join(" ").indexOf(x.arguments) > -1;
-          return true;
-        })) {
-          names[id] = name;
-          pids[id] = pid;
-
-          ids.push(id);
-          if (!timestamps[id]) {
-            log('detected game!', name);
-            timestamps[id] = Date.now();
-          }
-
-          // Resending this on evry scan is intentional, so that in the case that arRPC scans processes before Discord, existing activities will be sent
-          this.handlers.message({
-            socketId: id
-          }, {
-            cmd: 'SET_ACTIVITY',
-            args: {
-              activity: {
-                application_id: id,
-                name,
-                timestamps: {
-                  start: timestamps[id]
-                }
-              },
-              pid
-            }
-          });
+      else {
+        const toCompare = [];
+        const splitPath = path.split('/');
+        for (let i = 1; i < splitPath.length; i++) {
+          toCompare.push(splitPath.slice(-i).join('/'));
         }
+
+        for (const p of toCompare.slice()) { // add more possible tweaked paths for less false negatives
+          toCompare.push(p.replace('64', '')); // remove 64bit identifiers-ish
+          toCompare.push(p.replace('.x64', ''));
+          toCompare.push(p.replace('x64', ''));
+          toCompare.push(p.replace('_64', ''));
+        }
+        
+        for (const { executables, id, name } of DetectableDB) {
+          if (executables?.some(x => {
+            if (x.is_launcher) return false;
+            if (x.name[0] === '>' ? x.name.substring(1) !== toCompare[0] : !toCompare.some(y => x.name === y)) return false;
+            if (args && x.arguments) return args.join(" ").indexOf(x.arguments) > -1;
+            return true;
+          })) {
+            detected.push({ executables, id, name });
+          }
+        }
+        
+        cache[cacheKey] = {"detected": detected};
+      }
+      
+      for (const { executables, id, name } of detected) {
+        names[id] = name;
+        pids[id] = pid;
+
+        ids.push(id);
+        if (!timestamps[id]) {
+          log('detected game!', name);
+          timestamps[id] = Date.now();
+        }
+
+        // Resending this on evry scan is intentional, so that in the case that arRPC scans processes before Discord, existing activities will be sent
+        this.handlers.message({
+          socketId: id
+        }, {
+          cmd: 'SET_ACTIVITY',
+          args: {
+            activity: {
+              application_id: id,
+              name,
+              timestamps: {
+                start: timestamps[id]
+              }
+            },
+            pid
+          }
+        });
       }
     }
 


### PR DESCRIPTION
Inspired by a performance problem rightfully pointed out in PR #92, I set out to greatly optimize the process scan:

| Scenario              | Time  | Notes                                                                                         |
|-|-|-|
| **`main`** |         |                                                                                               |
| Before                | 🟨 133.7ms |                                                                                |
| After                 | 🟩 2.3ms   | Highly skewed due to what I think are GC spikes, most scans run way below 1ms!|
| **With #92** |         |                                                                                               |
| Before                | 🟥 2699ms  |                                                                                 |
| After                 | 🟩 0.3ms   | NOT faster than `main`, simply no GC spikes happened here                                         |

The change works on my end, but is also provably correct __(assuming `DetectableDB` does not change)__ because:
- the scan results depend on `DetectableDB`'s contents, `args`, and `toCompare`
- `toCompare` is derived from `splitPath`
- `splitPath` is derived from `path`

Notes:
- for the times, I subtracted the time it takes to get processes using `await Native.getProcesses();`. #92 does add functionality to this call but it's negligible (16.3ms -> 18.3ms)
- my system has a Ryzen 9 7940HS, the difference is much more significant on lower end setups where the process scan could have taken more than the 5 second budget and got into a loop of continuously consuming 1 CPU core!
- the results were recorded under no system activity, new processes coming to be will cause spikes but hopefully never worse than redundantly running every single process by `DetectableDB`.

Open questions:
- I'm not sure that the theoretically possible case of multiple `DetectableDB` entries being detected with one process is intentional, but I cache an array of all detected entries to keep this behavior