### PR TITLE
Linux: ignore suspended processes

### DIFF
--- a/src/process/native/linux.js
+++ b/src/process/native/linux.js
@@ -3,6 +3,15 @@ import { readdir, readFile } from "fs/promises";
 export const getProcesses = async () => (await Promise.all(
   (await readdir("/proc")).map(pid =>
     (+pid > 0) && readFile(`/proc/${pid}/cmdline`, 'utf8')
-      .then(path => [+pid, path.split("\0")[0], path.split("\0").slice(1)], () => 0)
+      .then(async path => {
+        try {
+          const status = await readFile(`/proc/${pid}/status`, 'utf8');
+          if (status.includes('State:\tT')) {
+            return null;
+          }
+        }
+        catch (err) {};
+        return [+pid, path.split("\0")[0], path.split("\0").slice(1)]
+      }, () => 0)
   )
 )).filter(x => x);


### PR DESCRIPTION
Under Linux, you can send a STOP signal to suspend a process. It will stay loaded, but will stop all processing. This can be used to load games and stop playing them. They will consume zero resources, besides the RAM/VRAM they've already allocated. Sending CONT will bring the game back to life, and you can get right back in without going through the loading screens, any logon processes etc.

It does not make sense that the user is playing the frozen frame (sometimes even that won't display) so exclude suspended processes.