### PR TITLE
fix(ws): implement a callback for deeplink events

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -168,7 +168,10 @@ export default class RPCServer extends EventEmitter {
         break;
 
       case 'DEEP_LINK':
-        this.emit('link', args.params);
+        const deep_callback = (success) => {
+          if (success) socket.send({ cmd, data: null, evt: null, nonce });
+        }
+        this.emit('link', args.params, deep_callback);
         break;
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -171,7 +171,7 @@ export default class RPCServer extends EventEmitter {
         const deep_callback = (success) => {
           if (success) socket.send({ cmd, data: null, evt: null, nonce });
         }
-        this.emit('link', args.params, deep_callback);
+        this.emit('link', args, deep_callback);
         break;
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -169,7 +169,7 @@ export default class RPCServer extends EventEmitter {
 
       case 'DEEP_LINK':
         const deep_callback = (success) => {
-          if (success) socket.send({ cmd, data: null, evt: null, nonce });
+          socket.send({ cmd, data: null, evt: success ? null : 'ERROR', nonce });
         }
         this.emit('link', args, deep_callback);
         break;


### PR DESCRIPTION
this is so discord web doesnt wait forever after emitting the event