### PR TITLE
fix: process detection if its a single path

### DIFF
--- a/src/process/index.js
+++ b/src/process/index.js
@@ -36,7 +36,7 @@ export default class ProcessServer {
 
     for (const [ pid, path, args ] of processes) {
       const splitPath = path.toLowerCase().replaceAll('\\', '/').split('/');
-      if ((/^[a-z]:$/.test(splitPath[0]) || splitPath[0] == "")) {
+      if ((splitPath[0] == 2 && splitPath[0].endsWith(':') || splitPath[0] == "")) {
         splitPath.shift(); // drop the first index if its a drive letter or empty
       }
 


### PR DESCRIPTION
`i = 1` rightly skips the first index as it is commonly empty (on linux) or a drive letter (windows) but this wrongly captures single path processes on linux. This explicitly filters out those undesired first indexes instead of skipping ALL of them.