### PR TITLE
server/activity: send correct button data

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -137,9 +137,11 @@ export default class RPCServer extends EventEmitter {
           cmd,
           data: {
             ...activity,
+            ...extra,
             name: "",
             application_id: socket.clientId,
-            type: 0
+            type: 0,
+            metadata
           },
           evt: null,
           nonce


### PR DESCRIPTION
It seems the C# project mentioned in #71 didn't include this in their own implementation, so it's not super apparent that it's also supposed to be sending back the button data in the same form as was emitted.

I noticed this because https://github.com/jewlexx/discord-presence didn't fully cooperate with Vencord because it complained it was deserializing the response incorrectly, so after inspecting the raw response I noticed the difference.