### PR TITLE
Shop/Discovery Menu Freeze Fix

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -169,8 +169,16 @@ export default class RPCServer extends EventEmitter {
 
       case 'DEEP_LINK':
         const deep_callback = (success) => {
-          socket.send({ cmd, data: null, evt: success ? null : 'ERROR', nonce });
+          socket.send({ cmd, data: success ? null : { code: 1001 }, evt: success ? null : 'ERROR', nonce });
         }
+
+        // Prevent Discord from staying in "Opening Discord App" loop-
+        // when going into shop/discovery menu
+        if (args.type === "SHOP" || args.type === "FEATURES") {
+          deep_callback(false)
+          break;
+        }
+
         this.emit('link', args, deep_callback);
         break;
     }


### PR DESCRIPTION
This commit fixes annoying bug that has been recently noticed with Shop and Discovery menu staying on "Opening Discord App" screen. Fix works by throwing an error whenever it detects the `SHOP` or `FEATURES` type of deep link.

Another addition to this code is returning error code (set to 1001 by default) to prevent Discord from throwing an error whenever it get's the "ERROR" response and can't find the error code. (From what I saw, it does nothing paticular anyways)

Sadly, Websocket disconnection is unavoidable as "ERROR" response automatically closes the connection so user has to refresh the page when leaving those places. There's no known workaround for this problem yet (besides maybe creating a Vencord plugin for this specific issue)

I am suspecting it works like this because Discord detects fingerprint/useragent which matches one for browser which instead of skipping "Opening Discord App" screen completely it waits for the one on desktop app. (even though there's none).

I honestly have no idea why they made these specific paths open Discord app.