### PR TITLE
Support systemd socket activation

### DIFF
--- a/src/bridge.js
+++ b/src/bridge.js
@@ -25,9 +25,15 @@ if (process.env.LISTEN_FDS) { // Socket activation
   port = { fd: 3 };
 }
 const wss = new WebSocketServer({ port });
+let quitTimer;
 
 wss.on('connection', socket => {
   log('web connected');
+  if (quitTimer) {
+    log('client reconnected, not deactivating')
+    clearTimeout(quitTimer);
+    quitTimer = undefined;
+  }
 
   for (const id in lastMsg) { // catch up newly connected
     if (lastMsg[id].activity != null) send(lastMsg[id]);
@@ -35,6 +41,10 @@ wss.on('connection', socket => {
 
   socket.on('close', () => {
     log('web disconnected');
+    if (process.env.LISTEN_FDS && wss.clients.size === 0) {
+      log('last client disconnected, will deactivate in 30s');
+      quitTimer = setTimeout(() => process.exit(0), 30000);
+    }
   });
 });
 


### PR DESCRIPTION
With socket activation, systemd can start the service when it's being used (and let it shut down when unused).

Example configuration:

`~/.config/systemd/user/arrpc.socket`

```ini
[Unit]
Description=arRPC Discord RPC bridge socket
Documentation=https://arrpc.openasar.dev/

[Socket]
ListenStream=127.0.0.1:1337
NoDelay=true

[Install]
WantedBy=sockets.target
```

`~/.config/systemd/user/arrpc.service`

```ini
[Unit]
Description=arRPC Discord RPC bridge
Documentation=https://arrpc.openasar.dev/

[Service]
#ExecStart=node %h/src/arrpc/src # (<<<use this instead of the below line with a path to a local git checkout, while the patch is not released yet)
ExecStart=npx arrpc
SendSIGHUP=true
Restart=on-failure
```

```
systemctl --user daemon-reload
systemctl --user enable --now arrpc.socket
```

(the units from [discord-flatpak-rpc-bridge](https://github.com/Arcitec/discord-flatpak-rpc-bridge) can be put into `~/.config/systemd/user/` as well btw)