### PR TITLE
Fix memory growth in bridge cache and process scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Open Discord RPC server for atypical setups",
   "main": "src/server.js",
   "scripts": {
-    "start": "node src"
+    "start": "node src",
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/src/bridge-clients.js
+++ b/src/bridge-clients.js
@@ -1,0 +1,20 @@
+export const MAX_BRIDGE_BUFFERED_AMOUNT = 1024 * 1024;
+
+export const sendToBridgeClients = (clients, msg, {
+  maxBufferedAmount = MAX_BRIDGE_BUFFERED_AMOUNT,
+  openState,
+  stringify = JSON.stringify
+} = {}) => {
+  const payload = stringify(msg);
+
+  for (const client of clients) {
+    if (openState != null && client.readyState !== openState) continue;
+
+    if (client.bufferedAmount > maxBufferedAmount) {
+      client.terminate?.();
+      continue;
+    }
+
+    client.send(payload);
+  }
+};

--- a/src/bridge-state.js
+++ b/src/bridge-state.js
@@ -1,0 +1,25 @@
+export const createBridgeState = () => {
+  const messages = new Map();
+
+  return {
+    update(msg) {
+      if (msg.socketId == null) return;
+
+      const socketId = msg.socketId.toString();
+      if (msg.activity == null) {
+        messages.delete(socketId);
+        return;
+      }
+
+      messages.set(socketId, msg);
+    },
+
+    replayable() {
+      return Array.from(messages.values());
+    },
+
+    get size() {
+      return messages.size;
+    }
+  };
+};

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,14 +1,15 @@
 const rgb = (r, g, b, msg) => `\x1b[38;2;${r};${g};${b}m${msg}\x1b[0m`;
 const log = (...args) => console.log(`[${rgb(88, 101, 242, 'arRPC')} > ${rgb(87, 242, 135, 'bridge')}]`, ...args);
 
-import { WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
+import { sendToBridgeClients } from './bridge-clients.js';
 import { createBridgeState } from './bridge-state.js';
 
 // basic bridge to pass info onto webapp
 const state = createBridgeState();
 export const send = msg => {
   state.update(msg);
-  wss.clients.forEach(x => x.send(JSON.stringify(msg)));
+  sendToBridgeClients(wss.clients, msg, { openState: WebSocket.OPEN });
 };
 
 let port = 1337;
@@ -24,7 +25,7 @@ wss.on('connection', socket => {
   log('web connected');
 
   for (const msg of state.replayable()) { // catch up newly connected
-    socket.send(JSON.stringify(msg));
+    sendToBridgeClients([socket], msg, { openState: WebSocket.OPEN });
   }
 
   socket.on('close', () => {

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -2,11 +2,12 @@ const rgb = (r, g, b, msg) => `\x1b[38;2;${r};${g};${b}m${msg}\x1b[0m`;
 const log = (...args) => console.log(`[${rgb(88, 101, 242, 'arRPC')} > ${rgb(87, 242, 135, 'bridge')}]`, ...args);
 
 import { WebSocketServer } from 'ws';
+import { createBridgeState } from './bridge-state.js';
 
 // basic bridge to pass info onto webapp
-let lastMsg = {};
+const state = createBridgeState();
 export const send = msg => {
-  lastMsg[msg.socketId] = msg;
+  state.update(msg);
   wss.clients.forEach(x => x.send(JSON.stringify(msg)));
 };
 
@@ -22,8 +23,8 @@ const wss = new WebSocketServer({ port });
 wss.on('connection', socket => {
   log('web connected');
 
-  for (const id in lastMsg) { // catch up newly connected
-    if (lastMsg[id].activity != null) send(lastMsg[id]);
+  for (const msg of state.replayable()) { // catch up newly connected
+    socket.send(JSON.stringify(msg));
   }
 
   socket.on('close', () => {

--- a/src/process/index.js
+++ b/src/process/index.js
@@ -9,6 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const DetectableDB = JSON.parse(fs.readFileSync(join(__dirname, 'detectable.json'), 'utf8'));
 
 import * as Natives from './native/index.js';
+import { createScanRunner } from './scan-runner.js';
 const Native = Natives[process.platform];
 
 
@@ -20,9 +21,10 @@ export default class ProcessServer {
     this.handlers = handlers;
 
     this.scan = this.scan.bind(this);
+    this.runScan = createScanRunner(this.scan);
 
-    this.scan();
-    setInterval(this.scan, 5000);
+    this.runScan();
+    setInterval(this.runScan, 5000);
 
     log('started');
   }

--- a/src/process/scan-runner.js
+++ b/src/process/scan-runner.js
@@ -1,0 +1,15 @@
+export const createScanRunner = scan => {
+  let running = false;
+
+  return async () => {
+    if (running) return false;
+
+    running = true;
+    try {
+      await scan();
+      return true;
+    } finally {
+      running = false;
+    }
+  };
+};

--- a/test/bridge-clients.test.js
+++ b/test/bridge-clients.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { sendToBridgeClients } from '../src/bridge-clients.js';
+
+test('does not queue messages for clients that are not open', () => {
+  const sent = [];
+  const clients = [
+    {
+      readyState: 3,
+      send: msg => sent.push(msg)
+    }
+  ];
+
+  sendToBridgeClients(clients, { activity: { name: 'Example' } }, { openState: 1 });
+
+  assert.deepEqual(sent, []);
+});
+
+test('terminates bridge clients with too much queued data', () => {
+  let terminated = false;
+  let sent = false;
+  const clients = [
+    {
+      readyState: 1,
+      bufferedAmount: 1025,
+      send: () => {
+        sent = true;
+      },
+      terminate: () => {
+        terminated = true;
+      }
+    }
+  ];
+
+  sendToBridgeClients(clients, { activity: { name: 'Example' } }, {
+    maxBufferedAmount: 1024,
+    openState: 1
+  });
+
+  assert.equal(sent, false);
+  assert.equal(terminated, true);
+});

--- a/test/bridge-state.test.js
+++ b/test/bridge-state.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createBridgeState } from '../src/bridge-state.js';
+
+test('removes cached activity when a socket clears it', () => {
+  const state = createBridgeState();
+  const active = {
+    socketId: '1',
+    activity: {
+      name: 'Example'
+    }
+  };
+
+  state.update(active);
+  assert.deepEqual(state.replayable(), [active]);
+
+  state.update({
+    socketId: '1',
+    activity: null
+  });
+
+  assert.equal(state.size, 0);
+  assert.deepEqual(state.replayable(), []);
+});
+
+test('does not grow when inactive sockets report null activity', () => {
+  const state = createBridgeState();
+
+  for (let i = 0; i < 1000; i++) {
+    state.update({
+      socketId: String(i),
+      activity: null
+    });
+  }
+
+  assert.equal(state.size, 0);
+});

--- a/test/process-scan-runner.test.js
+++ b/test/process-scan-runner.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createScanRunner } from '../src/process/scan-runner.js';
+
+test('does not start a scan while the previous scan is still running', async () => {
+  let starts = 0;
+  let finishFirstScan;
+
+  const runner = createScanRunner(() => {
+    starts++;
+    return new Promise(resolve => {
+      finishFirstScan = resolve;
+    });
+  });
+
+  const first = runner();
+  const second = runner();
+
+  assert.equal(starts, 1);
+  assert.equal(await second, false);
+
+  finishFirstScan();
+  assert.equal(await first, true);
+
+  const third = runner();
+  assert.equal(starts, 2);
+  finishFirstScan();
+  assert.equal(await third, true);
+});


### PR DESCRIPTION
## Summary
- clean up bridge activity cache entries when activity is cleared, so stale socket IDs do not accumulate
- prevent overlapping process scans by guarding scan execution, so a slow scan cannot pile up concurrent runs
- add bridge client send guards to avoid queueing unbounded buffered websocket data for slow or disconnected clients
- add regression tests covering all of the above

## Root Cause
Memory could grow over time from three places:
1. bridge cache retained socket entries after activity was cleared
2. process scanning used a fixed interval without overlap protection
3. bridge websocket broadcasting could keep buffering data for slow clients

## Changes
- `src/bridge-state.js`
  - introduced state container backed by `Map`
  - delete cached entry when `activity` is `null`

- `src/bridge.js`
  - switched replay/send path to use bridge state helper
  - switched broadcast path to a guarded client sender

- `src/bridge-clients.js`
  - added client send helper with:
    - `readyState` check
    - buffered amount threshold (`1MB`) and terminate on overflow

- `src/process/scan-runner.js`
  - added non-overlapping runner wrapper for async scans

- `src/process/index.js`
  - wired `createScanRunner` into interval scheduling to avoid concurrent scans

## Validation
- `npm test`

Test coverage added:
- `test/bridge-state.test.js`
- `test/process-scan-runner.test.js`
- `test/bridge-clients.test.js`
